### PR TITLE
fix get_service_version

### DIFF
--- a/sha_function.sh
+++ b/sha_function.sh
@@ -32,11 +32,11 @@ is_base (){
 get_service_version(){
     local version
     repo=$1
-    docker run -d $repo
-    container_id=$(docker ps | grep "webssh" | awk '{print$1;}')
-    echo $container_id
+    docker run -d $repo &>/dev/null
+    container_id=$(docker ps | grep "$repo" | awk '{print$1;}')
     version=$(docker exec -it $container_id wssh --version)
     echo $version
+    docker rm -f $container_id &>/dev/null
 }
 
 compare (){


### PR DESCRIPTION
get_service_version function printed container_id to the standard output, which caused versions mismatch.
The patch suppresses the docker command output, so the function only prints the wssh version now.